### PR TITLE
Charset Init

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -1,3 +1,5 @@
+scriptencoding utf-8
+set encoding=utf-8
 call pathogen#infect()
 let mapleader = "\<Space>"
 set nocompatible

--- a/vimrc
+++ b/vimrc
@@ -1,11 +1,12 @@
-scriptencoding utf-8
-set encoding=utf-8
 call pathogen#infect()
 let mapleader = "\<Space>"
 set nocompatible
 set viminfo='1000,f1,:1000,/1000
 set history=1000
 
+"------  Charset Init  ------
+scriptencoding utf-8
+set encoding=utf-8
 
 "------  Visual Options  ------
 syntax on


### PR DESCRIPTION
Solve problem with Debian 7.8

Error detected while processing /home/user/.vimrc:
line   21:
E474: Invalid argument: listchars=tab:�~V�\ ,trail:·,extends:�~]�,precedes:�~]�,nbsp:�~W
Press ENTER or type command to continue

Thanks for this awesome vim mod.